### PR TITLE
Register prestosql scalar functions

### DIFF
--- a/src/main/cpp/main/velox4j/init/Init.cc
+++ b/src/main/cpp/main/velox4j/init/Init.cc
@@ -30,6 +30,7 @@
 #include <velox/exec/PartitionFunction.h>
 #include <velox/experimental/stateful/StatefulPlanNode.h>
 #include <velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h>
+#include <velox/functions/prestosql/registration/RegistrationFunctions.h>
 #include <velox/functions/prestosql/window/WindowFunctionsRegistration.h>
 #include <velox/functions/sparksql/aggregates/Register.h>
 #include <velox/functions/sparksql/registration/Register.h>
@@ -68,6 +69,7 @@ void initForSpark() {
   parquet::registerParquetReaderFactory();
   parquet::registerParquetWriterFactory();
   functions::sparksql::registerFunctions();
+  functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions(
       "",
       true /*registerCompanionFunctions*/,

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/DiscardDataTableHandle.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/DiscardDataTableHandle.java
@@ -1,3 +1,19 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package io.github.zhztheplayer.velox4j.connector;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/FuzzerConnectorSplit.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/FuzzerConnectorSplit.java
@@ -1,3 +1,19 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package io.github.zhztheplayer.velox4j.connector;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -10,8 +26,7 @@ public class FuzzerConnectorSplit extends ConnectorSplit {
 
   @JsonCreator
   public FuzzerConnectorSplit(
-      @JsonProperty("connectorId") String connectorId,
-      @JsonProperty("numRows") int numRows) {
+      @JsonProperty("connectorId") String connectorId, @JsonProperty("numRows") int numRows) {
     super(connectorId, 0, true);
     this.numRows = numRows;
   }
@@ -30,5 +45,4 @@ public class FuzzerConnectorSplit extends ConnectorSplit {
   public int getNumRows() {
     return numRows;
   }
-
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/FuzzerTableHandle.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/FuzzerTableHandle.java
@@ -1,3 +1,19 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package io.github.zhztheplayer.velox4j.connector;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -9,8 +25,7 @@ public class FuzzerTableHandle extends ConnectorTableHandle {
 
   @JsonCreator
   public FuzzerTableHandle(
-          @JsonProperty("connectorId") String connectorId,
-          @JsonProperty("fuzzerSeed") int fuzzerSeed) {
+      @JsonProperty("connectorId") String connectorId, @JsonProperty("fuzzerSeed") int fuzzerSeed) {
     super(connectorId);
     this.fuzzerSeed = fuzzerSeed;
   }
@@ -19,5 +34,4 @@ public class FuzzerTableHandle extends ConnectorTableHandle {
   public int getSeed() {
     return fuzzerSeed;
   }
-
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/InsertTableHandle.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/InsertTableHandle.java
@@ -16,11 +16,11 @@
 */
 package io.github.zhztheplayer.velox4j.connector;
 
+import java.io.Serializable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.io.Serializable;
 
 public class InsertTableHandle implements Serializable {
   private final String connectorId;

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/NexmarkConnectorSplit.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/NexmarkConnectorSplit.java
@@ -1,3 +1,19 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package io.github.zhztheplayer.velox4j.connector;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -10,8 +26,7 @@ public class NexmarkConnectorSplit extends ConnectorSplit {
 
   @JsonCreator
   public NexmarkConnectorSplit(
-      @JsonProperty("connectorId") String connectorId,
-      @JsonProperty("numRows") int numRows) {
+      @JsonProperty("connectorId") String connectorId, @JsonProperty("numRows") int numRows) {
     super(connectorId, 0, true);
     this.numRows = numRows;
   }
@@ -20,5 +35,4 @@ public class NexmarkConnectorSplit extends ConnectorSplit {
   public int getNumRows() {
     return numRows;
   }
-
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/NexmarkTableHandle.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/NexmarkTableHandle.java
@@ -1,3 +1,19 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package io.github.zhztheplayer.velox4j.connector;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -6,9 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class NexmarkTableHandle extends ConnectorTableHandle {
 
   @JsonCreator
-  public NexmarkTableHandle(
-          @JsonProperty("connectorId") String connectorId) {
+  public NexmarkTableHandle(@JsonProperty("connectorId") String connectorId) {
     super(connectorId);
   }
-
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/FilterNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/FilterNode.java
@@ -18,10 +18,10 @@ package io.github.zhztheplayer.velox4j.plan;
 
 import java.util.List;
 
-import com.google.common.base.Preconditions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 
 import io.github.zhztheplayer.velox4j.expression.TypedExpr;
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/PlanNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/PlanNode.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import io.github.zhztheplayer.velox4j.exception.VeloxException;
 import io.github.zhztheplayer.velox4j.serializable.ISerializable;
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/ProjectNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/ProjectNode.java
@@ -18,10 +18,10 @@ package io.github.zhztheplayer.velox4j.plan;
 
 import java.util.List;
 
-import com.google.common.base.Preconditions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 
 import io.github.zhztheplayer.velox4j.expression.TypedExpr;
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/TableWriteNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/TableWriteNode.java
@@ -18,10 +18,10 @@ package io.github.zhztheplayer.velox4j.plan;
 
 import java.util.List;
 
-import com.google.common.base.Preconditions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 
 import io.github.zhztheplayer.velox4j.connector.CommitStrategy;
 import io.github.zhztheplayer.velox4j.connector.ConnectorInsertTableHandle;

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/WatermarkAssignerNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/WatermarkAssignerNode.java
@@ -1,11 +1,27 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package io.github.zhztheplayer.velox4j.plan;
 
-import com.google.common.base.Preconditions;
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.List;
+import com.google.common.base.Preconditions;
 
 public class WatermarkAssignerNode extends PlanNode {
   private List<PlanNode> sources;
@@ -15,11 +31,11 @@ public class WatermarkAssignerNode extends PlanNode {
 
   @JsonCreator
   public WatermarkAssignerNode(
-          @JsonProperty("id") String id,
-          @JsonProperty("sources") List<PlanNode> sources,
-          @JsonProperty("project") ProjectNode project,
-          @JsonProperty("idleTimeout") long idleTimeout,
-          @JsonProperty("rowtimeFieldIndex") int rowtimeFieldIndex) {
+      @JsonProperty("id") String id,
+      @JsonProperty("sources") List<PlanNode> sources,
+      @JsonProperty("project") ProjectNode project,
+      @JsonProperty("idleTimeout") long idleTimeout,
+      @JsonProperty("rowtimeFieldIndex") int rowtimeFieldIndex) {
     super(id);
     this.sources = sources;
     this.project = project;

--- a/src/main/java/io/github/zhztheplayer/velox4j/serde/NativeBean.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serde/NativeBean.java
@@ -18,5 +18,4 @@ package io.github.zhztheplayer.velox4j.serde;
 
 import java.io.Serializable;
 
-public interface NativeBean extends Serializable {
-}
+public interface NativeBean extends Serializable {}


### PR DESCRIPTION
### register prestosql scalar functions

To support `timestamp +/- interval` in https://github.com/apache/incubator-gluten/pull/9781.  It seems that in `sparksql`, there is no suitable function to achieve this.

### Format codes
let the style check pass