### PR TITLE
feat: 添加不带index的notifyWatermark接口

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -74,7 +74,7 @@ set(VELOX_SOURCE_URL "https://github.com/bigo-sg/velox.git")
 CPMAddPackage(
         NAME velox
         GIT_REPOSITORY ${VELOX_SOURCE_URL}
-        GIT_TAG 6f34a1f0a6225cbcd48fbb22e10d0ec91351a6ff
+        GIT_TAG 5ca51f107138e393aee00388156bda39c04ded9d
 )
 #set(VELOX_SOURCE_URL ${CMAKE_CURRENT_LIST_DIR}/build/_deps/velox-src)
 #CPMAddPackage(

--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -164,10 +164,17 @@ jobject statefulTaskGet(JNIEnv* env, jobject javaThis, jlong itrId) {
   JNI_METHOD_END(nullptr)
 }
 
-void notifyWatermark(JNIEnv* env, jobject javaThis, jlong itrId, jlong watermark, jint index) {
+void notifyIndexedWatermark(JNIEnv* env, jobject javaThis, jlong itrId, jlong watermark, jint index) {
   JNI_METHOD_START
   auto itr = ObjectStore::retrieve<StatefulSerialTask>(itrId);
   itr->notifyWatermark(watermark, index);
+  JNI_METHOD_END()
+}
+
+void notifyWatermark(JNIEnv* env, jobject javaThis, jlong itrId, jlong watermark) {
+  JNI_METHOD_START
+  auto itr = ObjectStore::retrieve<StatefulSerialTask>(itrId);
+  itr->notifyWatermark(watermark);
   JNI_METHOD_END()
 }
 
@@ -465,12 +472,19 @@ void JniWrapper::initialize(JNIEnv* env) {
        kTypeLong,
        nullptr);
   addNativeMethod(
+      "notifyIndexedWatermark",
+       (void*)notifyIndexedWatermark,
+       kTypeVoid,
+       kTypeLong,
+       kTypeLong,
+       kTypeInt,
+       nullptr);
+  addNativeMethod(
       "notifyWatermark",
        (void*)notifyWatermark,
        kTypeVoid,
        kTypeLong,
        kTypeLong,
-       kTypeInt,
        nullptr);
   addNativeMethod(
       "initializeState",

--- a/src/main/cpp/main/velox4j/query/StatefulQueryExecutor.cc
+++ b/src/main/cpp/main/velox4j/query/StatefulQueryExecutor.cc
@@ -100,6 +100,10 @@ void StatefulSerialTask::notifyWatermark(long watermark, int index) {
   task_->notifyWatermark(watermark, index);
 }
 
+void StatefulSerialTask::notifyWatermark(long watermark) {
+  task_->notifyWatermark(watermark);
+}
+
 void StatefulSerialTask::initializeState(long checkpointId) {
   task_->initializeState();
 }

--- a/src/main/cpp/main/velox4j/query/StatefulQueryExecutor.h
+++ b/src/main/cpp/main/velox4j/query/StatefulQueryExecutor.h
@@ -43,6 +43,8 @@ class StatefulSerialTask : public UpIterator {
 
   void notifyWatermark(long watermark, int index);
 
+  void notifyWatermark(long watermark);
+
   void initializeState(long checkpointId);
 
   void snapshotState(long checkpointId);

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
@@ -98,7 +98,11 @@ public final class JniApi {
   }
 
   public void notifyWatermark(UpIterator itr, long watermark, int index) {
-    jni.notifyWatermark(itr.id(), watermark, index);
+    jni.notifyIndexedWatermark(itr.id(), watermark, index);
+  }
+
+  public void notifyWatermark(UpIterator itr, long watermark) {
+    jni.notifyWatermark(itr.id(), watermark);
   }
 
   public void initializeState(UpIterator itr, long context) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
@@ -53,7 +53,10 @@ final class JniWrapper {
   native StatefulElement statefulTaskGet(long id);
 
   // For Flink.
-  native void notifyWatermark(long id, long watermark, int index);
+  native void notifyIndexedWatermark(long id, long watermark, int index);
+
+  // For Flink.
+  native void notifyWatermark(long id, long watermark);
 
   native void initializeState(long id, long context);
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/query/SerialTask.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/query/SerialTask.java
@@ -57,6 +57,11 @@ public class SerialTask implements UpIterator {
     jniApi.notifyWatermark(this, watermark, index);
   }
 
+  // This method is for Flink
+  public void notifyWatermark(long watermark) {
+    jniApi.notifyWatermark(this, watermark);
+  }
+
   @Override
   public long id() {
     return id;


### PR DESCRIPTION
- 在StatefulSerialTask中添加notifyWatermark(long watermark)方法
- 在JNI层添加notifyWatermark和notifyIndexedWatermark两个接口
- 将原有的notifyWatermark(带index)重命名为notifyIndexedWatermark
- 在SerialTask中添加不带index的notifyWatermark公共方法
- 最终调用velox的相应不带index的接口