### PR TITLE
fix: use buffered I/O in Resources.copyResource

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/resource/Resources.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/resource/Resources.java
@@ -169,12 +169,10 @@ public class Resources {
             Preconditions.checkNotNull(
                 classloader.getResourceAsStream(fromPath), "Resource %s not found", fromPath))) {
       final BufferedOutputStream o = new BufferedOutputStream(new FileOutputStream(toFile));
-      while (true) {
-        int b = is.read();
-        if (b == -1) {
-          break;
-        }
-        o.write(b);
+      byte[] buf = new byte[8192];
+      int n;
+      while ((n = is.read(buf)) != -1) {
+        o.write(buf, 0, n);
       }
       o.flush();
       o.close();


### PR DESCRIPTION
# fix: use buffered I/O in Resources.copyResource

## Problem

`Resources.copyResource()` reads and writes resource files one byte at a time. This is used during JNI native library loading to extract `.so` files from the JAR to a temp directory. With ~33 shared libraries (~100MB total), byte-by-byte copying causes a **~40 second delay** on every Flink cluster (TaskManager) startup. #30 

The three largest libraries alone account for ~37 seconds:

| Library | Size | Copy Time |
|---------|------|-----------|
| libvelox.so | 58MB | 23,823 ms |
| libfolly.so | 27MB | 10,629 ms |
| libicudata.so.74 | 28MB | 2,764 ms |

## Benchmark

Tested with 33 native libraries on aarch64 Linux during Flink TaskManager startup:

| Metric | Before (byte-by-byte) | After (8KB buffer) | Speedup |
|--------|----------------------|-------------------|---------|
| **Total copy time** | **39,448 ms (~40s)** | **2,149 ms (~2s)** | **18.4x** |
| libvelox.so | 23,823 ms | 1,076 ms | 22.1x |
| libfolly.so | 10,629 ms | 722 ms | 14.7x |
| libicudata.so.74 | 2,764 ms | 186 ms | 14.9x |
| libcrypto.so.3 | 388 ms | 28 ms | 13.9x |
| libicui18n.so.74 | 273 ms | 27 ms | 10.1x |
| libvelox4j.so | 275 ms | 14 ms | 19.6x |
| librdkafka.so.1 | 168 ms | 12 ms | 14.0x |
| libcppkafka.so.0.4.1 | 141 ms | 8 ms | 17.6x |

## Files Changed

- `src/main/java/io/github/zhztheplayer/velox4j/resource/Resources.java`