### PR TITLE
[FLINK] Fix print connector: mirror PrintTableHandle changes (drop path, add printIdentifier/isStdErr)

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -64,17 +64,17 @@ list(PREPEND CMAKE_MODULE_PATH
      ${CMAKE_CURRENT_LIST_DIR}/cmake/resolve_dependency_modules)
 set(VELOX_REF_FILE ${CMAKE_CURRENT_LIST_DIR}/velox-ref.txt)
 set(VELOX_REF_HASH_FILE ${CMAKE_CURRENT_LIST_DIR}/velox-ref-hash.txt)
-set(VELOX_REPO bigo-sg/velox)
+set(VELOX_REPO ggjh-159/velox)
 file(STRINGS ${VELOX_REF_FILE} VELOX_REF)
 file(STRINGS ${VELOX_REF_HASH_FILE} VELOX_SOURCE_URL_MD5)
-set(VELOX_SOURCE_URL "https://github.com/bigo-sg/velox.git")
+set(VELOX_SOURCE_URL "https://github.com/ggjh-159/velox.git")
 cpmaddpackage(
   NAME
   velox
   GIT_REPOSITORY
   ${VELOX_SOURCE_URL}
   GIT_TAG
-  be3e18f53a2cc655bb743c8bf2afb312dbd40ee4)
+  fix/print-sink-multi-parallelism)
 
 # Import JniHelpers.
 set(JNI_HELPERS_REPO zhztheplayer/JniHelpersCpp)

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -64,7 +64,7 @@ list(PREPEND CMAKE_MODULE_PATH
      ${CMAKE_CURRENT_LIST_DIR}/cmake/resolve_dependency_modules)
 set(VELOX_REF_FILE ${CMAKE_CURRENT_LIST_DIR}/velox-ref.txt)
 set(VELOX_REF_HASH_FILE ${CMAKE_CURRENT_LIST_DIR}/velox-ref-hash.txt)
-
+set(VELOX_REPO bigo-sg/velox)
 file(STRINGS ${VELOX_REF_FILE} VELOX_REF)
 file(STRINGS ${VELOX_REF_HASH_FILE} VELOX_SOURCE_URL_MD5)
 set(VELOX_SOURCE_URL "https://github.com/bigo-sg/velox.git")

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/PrintTableHandle.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/PrintTableHandle.java
@@ -25,16 +25,19 @@ public class PrintTableHandle extends ConnectorInsertTableHandle {
 
   private String tableName;
   private RowType dataColumns;
-  private String path;
+  private String printIdentifier;
+  private boolean isStdErr;
 
   @JsonCreator
   public PrintTableHandle(
       @JsonProperty("tableName") String tableName,
       @JsonProperty("dataColumns") RowType dataColumns,
-      @JsonProperty("path") String path) {
+      @JsonProperty("printIdentifier") String printIdentifier,
+      @JsonProperty("isStdErr") boolean isStdErr) {
     this.tableName = tableName;
     this.dataColumns = dataColumns;
-    this.path = path;
+    this.printIdentifier = printIdentifier == null ? "" : printIdentifier;
+    this.isStdErr = isStdErr;
   }
 
   @Override
@@ -52,8 +55,13 @@ public class PrintTableHandle extends ConnectorInsertTableHandle {
     return dataColumns;
   }
 
-  @JsonProperty("path")
-  public String getPath() {
-    return path;
+  @JsonProperty("printIdentifier")
+  public String getPrintIdentifier() {
+    return printIdentifier;
+  }
+
+  @JsonProperty("isStdErr")
+  public boolean isStdErr() {
+    return isStdErr;
   }
 }

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/ConnectorSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/ConnectorSerdeTest.java
@@ -107,6 +107,20 @@ public class ConnectorSerdeTest {
   }
 
   @Test
+  public void testPrintTableHandle() {
+    final PrintTableHandle handle =
+        new PrintTableHandle("print-table", SerdeTests.newSampleOutputType(), "foo", true);
+    SerdeTests.testISerializableRoundTrip(handle);
+  }
+
+  @Test
+  public void testPrintTableHandleEmptyIdentifier() {
+    final PrintTableHandle handle =
+        new PrintTableHandle("print-table", SerdeTests.newSampleOutputType(), null, false);
+    SerdeTests.testISerializableRoundTrip(handle);
+  }
+
+  @Test
   public void testLocationHandle() {
     final LocationHandle handle = SerdeTests.newSampleLocationHandle();
     SerdeTests.testISerializableRoundTrip(handle);


### PR DESCRIPTION
fix: https://github.com/apache/gluten/issues/12306
related prs: https://github.com/bigo-sg/velox/pull/49 https://github.com/apache/gluten/pull/12320

## Summary

Track the companion velox PR that replaces the dwio-file print sink with stdout/stderr output. The Java `PrintTableHandle` must serialize the same keys the C++ side now expects.

- Drop `path`, add `printIdentifier` (`String`, defaults to `""` when null) and `isStdErr` (`boolean`) on `PrintTableHandle`, with matching `@JsonCreator` / `@JsonProperty` wiring.
- The C++ side now emits a `"name": "PrintTableHandle"` discriminator; the Java POJO inherits it for free through `SerdeRegistry`, so no annotation changes are required — the test asserts the round-trip.

## Test

- UTs
- End-to-end via the companion gluten-flink PR: nexmark q0 with `parallelism.default = 2` produces one line per bid with the `1> ` / `2> ` prefix, written to `flink-*-taskmanager-*.out` (no file path plumbing).