### PR TITLE
fix: velox4j shouldn't crash and should pass exception to flink

### DIFF
--- a/src/main/cpp/main/velox4j/init/Config.cc
+++ b/src/main/cpp/main/velox4j/init/Config.cc
@@ -17,9 +17,26 @@
 
 #include "Config.h"
 
+#include <atomic>
+
 namespace velox4j {
 using namespace facebook::velox;
 config::ConfigBase::Entry<Preset> VELOX4J_INIT_PRESET(
     "velox4j.init.preset",
     Preset::SPARK);
+config::ConfigBase::Entry<bool> VELOX4J_MEMORY_MANAGER_FAIL_ON_LEAK(
+    "velox4j.memory-manager.fail-on-leak",
+    false);
+
+namespace {
+std::atomic<bool> memoryManagerFailOnLeak_{false};
+}
+
+void setMemoryManagerFailOnLeak(bool failOnLeak) {
+  memoryManagerFailOnLeak_.store(failOnLeak);
+}
+
+bool memoryManagerFailOnLeak() {
+  return memoryManagerFailOnLeak_.load();
+}
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/init/Config.h
+++ b/src/main/cpp/main/velox4j/init/Config.h
@@ -23,4 +23,9 @@ namespace velox4j {
 enum Preset { SPARK = 0 };
 
 extern facebook::velox::config::ConfigBase::Entry<Preset> VELOX4J_INIT_PRESET;
+extern facebook::velox::config::ConfigBase::Entry<bool>
+    VELOX4J_MEMORY_MANAGER_FAIL_ON_LEAK;
+
+void setMemoryManagerFailOnLeak(bool failOnLeak);
+bool memoryManagerFailOnLeak();
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/init/Init.cc
+++ b/src/main/cpp/main/velox4j/init/Init.cc
@@ -217,6 +217,8 @@ void initialize(const std::shared_ptr<ConfigArray>& configArray) {
     google::InitGoogleLogging("velox");
     auto vConfig = std::make_shared<facebook::velox::config::ConfigBase>(
         configArray->toMap());
+    setMemoryManagerFailOnLeak(
+        vConfig->get(VELOX4J_MEMORY_MANAGER_FAIL_ON_LEAK));
     auto preset = vConfig->get(VELOX4J_INIT_PRESET);
     switch (preset) {
       case SPARK:

--- a/src/main/cpp/main/velox4j/jni/JniCommon.h
+++ b/src/main/cpp/main/velox4j/jni/JniCommon.h
@@ -35,6 +35,12 @@
     env->ThrowNew(                                                     \
         velox4j::getJniErrorState()->veloxExceptionClass(), e.what()); \
     return fallback_expr;                                              \
+  }                                                                    \
+  catch (...) {                                                        \
+    env->ThrowNew(                                                     \
+        velox4j::getJniErrorState()->veloxExceptionClass(),            \
+        "Unknown native exception");                                   \
+    return fallback_expr;                                              \
   }
 // macro ended
 #endif

--- a/src/main/cpp/main/velox4j/memory/MemoryManager.cc
+++ b/src/main/cpp/main/velox4j/memory/MemoryManager.cc
@@ -17,6 +17,7 @@
 
 #include "MemoryManager.h"
 #include "ArrowMemoryPool.h"
+#include "velox4j/init/Config.h"
 
 namespace velox4j {
 using namespace facebook;
@@ -353,12 +354,20 @@ MemoryManager::~MemoryManager() {
   } catch (const std::exception& ex) {
     LOG(ERROR) << "[Velox4J MemoryManager DTOR] "
                << " Error occurred: " << ex.what();
+  } catch (...) {
+    LOG(ERROR) << "[Velox4J MemoryManager DTOR] Unknown error occurred";
   }
   if (!succeeded) {
+    if (memoryManagerFailOnLeak()) {
+      LOG(ERROR) << "[Velox4J MemoryManager DTOR] "
+                 << "Fatal: Memory leak found, aborting the destruction of "
+                    "MemoryManager. This could cause the process to crash.";
+      VELOX_FAIL("Memory leak found during destruction of MemoryManager");
+    }
     LOG(ERROR) << "[Velox4J MemoryManager DTOR] "
-               << "Fatal: Memory leak found, aborting the destruction of "
-                  "MemoryManager. This could cause the process to crash.";
-    VELOX_FAIL("Memory leak found during destruction of MemoryManager");
+               << "Memory leak found during destruction of MemoryManager. "
+                  "Continuing because velox4j.memory-manager.fail-on-leak "
+                  "is false.";
   }
 }
 

--- a/src/main/cpp/main/velox4j/query/QueryExecutor.cc
+++ b/src/main/cpp/main/velox4j/query/QueryExecutor.cc
@@ -17,6 +17,7 @@
 
 #include "QueryExecutor.h"
 
+#include <glog/logging.h>
 #include <velox/exec/Operator.h>
 #include <velox/exec/PlanNodeStats.h>
 #include <velox/exec/Task.h>
@@ -76,10 +77,16 @@ SerialTask::SerialTask(
 }
 
 SerialTask::~SerialTask() {
-  if (task_ != nullptr && task_->isRunning()) {
-    // FIXME: Calling .wait() may take no effect in single thread execution
-    //  mode.
-    task_->requestCancel().wait();
+  try {
+    if (task_ != nullptr && task_->isRunning()) {
+      // FIXME: Calling .wait() may take no effect in single thread execution
+      //  mode.
+      task_->requestCancel().wait();
+    }
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Error while destroying SerialTask: " << e.what();
+  } catch (...) {
+    LOG(ERROR) << "Unknown error while destroying SerialTask";
   }
 }
 

--- a/src/main/cpp/main/velox4j/query/StatefulQueryExecutor.cc
+++ b/src/main/cpp/main/velox4j/query/StatefulQueryExecutor.cc
@@ -19,6 +19,7 @@
 #include <folly/json.h>
 #include <folly/json/dynamic.h>
 #include <folly/json/json.h>
+#include <glog/logging.h>
 #include <velox/experimental/stateful/state/RocksDBStateBackend.h>
 #include <velox/experimental/stateful/state/StateBackend.h>
 #include <exception>
@@ -81,17 +82,23 @@ StatefulSerialTask::StatefulSerialTask(
 }
 
 StatefulSerialTask::~StatefulSerialTask() {
-  if (task_ != nullptr && task_->isRunning()) {
-    // TODO: add a method to finish the task and set state.
-    task_->finish();
-    // FIXME: Calling .wait() may take no effect in single thread execution
-    //  mode.
-    task_->requestCancel().wait();
+  try {
+    if (task_ != nullptr && task_->isRunning()) {
+      // TODO: add a method to finish the task and set state.
+      task_->finish(false);
+      // FIXME: Calling .wait() may take no effect in single thread execution
+      //  mode.
+      task_->requestCancel().wait();
+    }
+    if (task_ != nullptr) {
+      task_->setNativeCallbackBridge(nullptr);
+    }
+    task_.reset();
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Error while destroying StatefulSerialTask: " << e.what();
+  } catch (...) {
+    LOG(ERROR) << "Unknown error while destroying StatefulSerialTask";
   }
-  if (task_ != nullptr) {
-    task_->setNativeCallbackBridge(nullptr);
-  }
-  task_.reset();
 }
 
 UpIterator::State StatefulSerialTask::advance() {

--- a/src/main/java/io/github/zhztheplayer/velox4j/Velox4j.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/Velox4j.java
@@ -34,6 +34,8 @@ import io.github.zhztheplayer.velox4j.session.Session;
 import io.github.zhztheplayer.velox4j.variant.VariantRegistry;
 
 public class Velox4j {
+  public static final String MEMORY_MANAGER_FAIL_ON_LEAK = "velox4j.memory-manager.fail-on-leak";
+
   private static final AtomicBoolean initialized = new AtomicBoolean(false);
   private static final Map<String, String> globalConfMap = new LinkedHashMap<>();
 


### PR DESCRIPTION
related issue: https://github.com/apache/gluten/issues/12208

some cases would lead to velox crash, and failover can not be controlled by flink
- exception throw from destructor function, like `SerialTask`, `StatefulSerialTask`,  we add `try... catch` to catch the exception
- in the destructor of `MemoryManager`, if the memory leaks, velox4j would throw excption and crash, we use a config `velox4j.memory-manager.fail-on-leak` to controll it not throw exception, but only print logs
- the jni call may also throw exception in `JniCommon.h` and lead to crash, we add `try...catch` block to catch the excpetion