### PR TITLE
fix: include null value in VarCharValue serde

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/VarCharValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/VarCharValue.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class VarCharValue extends Variant {
@@ -31,6 +32,7 @@ public class VarCharValue extends Variant {
   }
 
   @JsonGetter("value")
+  @JsonInclude(JsonInclude.Include.ALWAYS)
   public String getValue() {
     return value;
   }

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/VariantSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/VariantSerdeTest.java
@@ -107,6 +107,7 @@ public class VariantSerdeTest {
   @Test
   public void testVarCharValue() {
     SerdeTests.testVariantRoundTrip(new VarCharValue("foo"));
+    SerdeTests.testVariantRoundTrip(new VarCharValue(null));
   }
 
   @Test


### PR DESCRIPTION
## What changes are proposed in this pull request?

The global Jackson config (`Serde.java:46`) sets `JsonInclude.Include.NON_NULL`, which drops any field whose value is `null`. When a `VarCharValue` holds a null string — e.g. produced by `COALESCE(CAST(NULL AS STRING), x)` in a Flink plan — the `value` key is stripped from the JSON payload, and the C++ `variant::create` side then throws because it cannot find the required `value` key. See the linked issue(#61) for the full reproducer and error trace.

### Fix

Add `@JsonInclude(JsonInclude.Include.ALWAYS)` on `VarCharValue.getValue()` to override the global config for that field, so the `value` key is always emitted (as JSON `null` when the string is null). This matches the canonical format that C++ `variant::serialize()` produces for null variants (`Variant.cpp:548-549`).

## How was this patch tested?

`VariantSerdeTest.testVarCharValue` now also covers the null case